### PR TITLE
Repeat Pomodoro x number of times 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,22 +67,23 @@ You can then type `help` to get all the options.
 #
 # Options:
 #
-#   --help               output usage information
-#   -t, --time <time>    Set the time of the Pomodoro. Default is 25:00 minutes.
-#   -c, --chill <chill>  Set the time of chill. Default is 5:00 minutes.
-#   -l, --loop           Run continues Pomodoros.
+#   --help                 output usage information
+#   -t, --time <time>      Set the time of the Pomodoro. Default is 25:00 minutes.
+#   -c, --chill <chill>    Set the time of chill. Default is 5:00 minutes.
+#   -r, --repeat <repeat>  Repeat Pomodero x times. Default is 1.
+#   -l, --loop             Run Pomodoros forever.
 ```
 
-You can then start continues Pomodoros of 20 minutes with 3 minute breaks:
+You can then start Pomodoros of 20 minutes with a 3 minute break, repeated 6 times:
 
 ```sh
-🍅 start --time 20:00 --chill 03:00
+🍅 start --time 20:00 --chill 03:00 --repeat 6
 ```
 
 The time can also be specified in a shorthand format:
 
 ```sh
-🍅 start -t 20m -c 3m
+🍅 start -t 20m -c 3m -r 6
 ```
 
 You can also enter multiple time and chill parameters (e.g. Work 50 minutes, chill 10 minutes, work 50 minutes, chill 25 minutes, forever):

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can then type `help` to get all the options.
 #   -l, --loop             Run Pomodoros forever.
 ```
 
-You can then start Pomodoros of 20 minutes with a 3 minute break, repeated 6 times:
+You can then start Pomodoros of 20 minutes with 3 minutes break, repeated 6 times:
 
 ```sh
 🍅 start --time 20:00 --chill 03:00 --repeat 6
@@ -86,10 +86,16 @@ The time can also be specified in a shorthand format:
 🍅 start -t 20m -c 3m -r 6
 ```
 
+Pomodero can run infinitely:
+
+```sh
+🍅 start -t 20m -c 3m --loop
+```
+
 You can also enter multiple time and chill parameters (e.g. Work 50 minutes, chill 10 minutes, work 50 minutes, chill 25 minutes, forever):
 
 ```sh
-🍅 start -t 50m -c 10m -t 50m -c 25 --loop
+🍅 start -t 50m -c 10m -t 50m -c 25 -l
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -57,8 +57,7 @@ const performPomodoro = (times, chills, index, cb) => {
     clearLineAndWrite(`🕐 ${time} - ${sessionCurrentTick} ∞`)
   } else {
     clearLineAndWrite(`🕐 ${time} - ${sessionCurrentTick}`)
-  }
-  
+  } 
 
   timer.start()
   renderTime(time, timer, sessionCurrentTick)
@@ -76,7 +75,12 @@ const performPomodoro = (times, chills, index, cb) => {
     // Setup chill timer
     const timer = Timr(chill)
     const chillCurrentTick = `Chill ${currentTick}`
-    clearLineAndWrite(`🕐 ${chill} - ${chillCurrentTick}`)
+
+    if (loop) {
+      clearLineAndWrite(`🕐 ${chill} - ${chillCurrentTick} ∞`)
+    } else {
+      clearLineAndWrite(`🕐 ${chill} - ${chillCurrentTick}`)
+    }
     timer.start()
     renderTime(chill, timer, chillCurrentTick)
 

--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ const clearLineAndWrite = text => {
 require('update-notifier')({ pkg }).notify()
 
 // Default args if none provided
-const defaultTime = '00:05'
-const chillTime = '00:02'
+const defaultTime = '25:00'
+const chillTime = '05:00'
 const defaultRepeat = 1
 
 let timerRunning = false
@@ -32,6 +32,8 @@ const renderTime = (time, timer, type) => {
     if (!timerRunning) {
       timer.stop()
       clearLineAndWrite('🍅 ')
+    } else if (loop) {
+      clearLineAndWrite(`🕐 ${formattedTime} - ${type} ∞`)
     } else {
       clearLineAndWrite(`🕐 ${formattedTime} - ${type}`)
     }
@@ -41,17 +43,22 @@ const renderTime = (time, timer, type) => {
 const performPomodoro = (times, chills, index, cb) => {
   timerRunning = true
 
-  const time = times[index] || times[repeatTime % index]
-  const chill = chills[index] || chills[repeatTime % index]
+  const time = times[index] || times[repeatTime % index] || times[index % repeatTime]
+  const chill = chills[index] || chills[repeatTime % index] || chills[index % repeatTime]
   const currentTick = `(${index + 1}/${repeatTime * times.length})`
-  // const currentTick = `(${index + 1}/${times.length})`
 
   stats.set('total', Number.parseInt(stats.get('total') || 0) + 1, { overwrite: true })
 
   // Setup session timer
   const timer = Timr(time)
   const sessionCurrentTick = `Session ${currentTick}`
-  clearLineAndWrite(`🕐 ${time} - ${sessionCurrentTick}`)
+
+  if (loop) {
+    clearLineAndWrite(`🕐 ${time} - ${sessionCurrentTick} ∞`)
+  } else {
+    clearLineAndWrite(`🕐 ${time} - ${sessionCurrentTick}`)
+  }
+  
 
   timer.start()
   renderTime(time, timer, sessionCurrentTick)
@@ -80,8 +87,6 @@ const performPomodoro = (times, chills, index, cb) => {
         message: `Chill done! ${currentTick}`,
         sound: true
       })
-
-      clearLineAndWrite(`♻️ repeatTime: ${repeatTime} 🧐 loop: ${loop}`)
 
       if (index < repeatTime - 1) {
         performPomodoro(times, chills, index + 1, cb)

--- a/index.js
+++ b/index.js
@@ -19,11 +19,13 @@ const clearLineAndWrite = text => {
 require('update-notifier')({ pkg }).notify()
 
 // Default args if none provided
-const defaultTime = '25:00'
-const chillTime = '05:00'
+const defaultTime = '00:05'
+const chillTime = '00:02'
+const defaultRepeat = 1
 
 let timerRunning = false
 let loop = false
+let repeatTime = defaultRepeat
 
 const renderTime = (time, timer, type) => {
   timer.ticker(({ formattedTime }) => {
@@ -41,7 +43,8 @@ const performPomodoro = (times, chills, index, cb) => {
 
   const time = times[index]
   const chill = chills[index]
-  const currentTick = `(${index + 1}/${times.length})`
+  const currentTick = `(${index + 1}/${repeatTime})`
+  // const currentTick = `(${index + 1}/${times.length})`
 
   stats.set('total', Number.parseInt(stats.get('total') || 0) + 1, { overwrite: true })
 
@@ -49,6 +52,7 @@ const performPomodoro = (times, chills, index, cb) => {
   const timer = Timr(time)
   const sessionCurrentTick = `Session ${currentTick}`
   clearLineAndWrite(`🕐 ${time} - ${sessionCurrentTick}`)
+
   timer.start()
   renderTime(time, timer, sessionCurrentTick)
 
@@ -61,6 +65,8 @@ const performPomodoro = (times, chills, index, cb) => {
       message: `Pomodoro done! ${currentTick}`,
       sound: true
     })
+
+    clearLineAndWrite(`🐜 repeat: ${repeatTime}`)
 
     // Setup chill timer
     const timer = Timr(chill)
@@ -77,9 +83,12 @@ const performPomodoro = (times, chills, index, cb) => {
         sound: true
       })
 
-      if (times.length - 1 > index) {
+      clearLineAndWrite(`♻️ repeatTime: ${repeatTime} 🧐 time: ${time}`)
+
+      if (index < repeatTime - 1) {
+      // if (times.length - 1 > index) {
         performPomodoro(times, chills, index + 1, cb)
-      } else if (loop) {
+      } else if (repeatTime == 0) {
         performPomodoro(times, chills, 0, cb)
       } else {
         cb()
@@ -90,13 +99,14 @@ const performPomodoro = (times, chills, index, cb) => {
 
 vorpal
   .command('start', 'Start a Pomodoro')
-  .autocomplete(['--time', '--chill'])
+  .autocomplete(['--time', '--chill', '--repeat'])
   .option('-t, --time <time>', 'Set the time of the Pomodoro. Default is 25:00 minutes.')
   .option('-c, --chill <chill>', 'Set the time of chill. Default is 5:00 minutes.')
-  .option('-l, --loop', 'Run continuous Pomodoros.')
+  .option('-r, --repeat <repeat>', 'Run x Pomodoros. Default is 1. To run continuous Pomodoros, set to 0')
   .action((args = {}, cb) => {
     let times = args.options.time || [defaultTime]
     let chills = args.options.chill || [chillTime]
+    repeatTime = args.options.repeat || defaultRepeat
 
     if (!Array.isArray(times)) {
       times = [times]
@@ -111,7 +121,8 @@ vorpal
       )
       cb()
     } else {
-      loop = args.options.loop || false
+      // Debug
+      clearLineAndWrite(`♻️ ${repeatTime}`)
       performPomodoro(times, chills, 0, cb)
     }
   })

--- a/index.js
+++ b/index.js
@@ -41,8 +41,8 @@ const renderTime = (time, timer, type) => {
 const performPomodoro = (times, chills, index, cb) => {
   timerRunning = true
 
-  const time = times[index]
-  const chill = chills[index]
+  const time = times[index] || times[0]
+  const chill = chills[index] || chills[0]
   const currentTick = `(${index + 1}/${repeatTime})`
   // const currentTick = `(${index + 1}/${times.length})`
 
@@ -122,7 +122,7 @@ vorpal
       cb()
     } else {
       // Debug
-      clearLineAndWrite(`♻️ ${repeatTime}`)
+      clearLineAndWrite(`🛠 debug passing in repeat time ${repeatTime}`)
       performPomodoro(times, chills, 0, cb)
     }
   })

--- a/index.js
+++ b/index.js
@@ -41,9 +41,9 @@ const renderTime = (time, timer, type) => {
 const performPomodoro = (times, chills, index, cb) => {
   timerRunning = true
 
-  const time = times[index] || times[0]
-  const chill = chills[index] || chills[0]
-  const currentTick = `(${index + 1}/${repeatTime})`
+  const time = times[index] || times[repeatTime % index]
+  const chill = chills[index] || chills[repeatTime % index]
+  const currentTick = `(${index + 1}/${repeatTime * times.length})`
   // const currentTick = `(${index + 1}/${times.length})`
 
   stats.set('total', Number.parseInt(stats.get('total') || 0) + 1, { overwrite: true })
@@ -66,8 +66,6 @@ const performPomodoro = (times, chills, index, cb) => {
       sound: true
     })
 
-    clearLineAndWrite(`🐜 repeat: ${repeatTime}`)
-
     // Setup chill timer
     const timer = Timr(chill)
     const chillCurrentTick = `Chill ${currentTick}`
@@ -83,12 +81,11 @@ const performPomodoro = (times, chills, index, cb) => {
         sound: true
       })
 
-      clearLineAndWrite(`♻️ repeatTime: ${repeatTime} 🧐 time: ${time}`)
+      clearLineAndWrite(`♻️ repeatTime: ${repeatTime} 🧐 loop: ${loop}`)
 
       if (index < repeatTime - 1) {
-      // if (times.length - 1 > index) {
         performPomodoro(times, chills, index + 1, cb)
-      } else if (repeatTime == 0) {
+      } else if (loop) {
         performPomodoro(times, chills, 0, cb)
       } else {
         cb()
@@ -102,11 +99,11 @@ vorpal
   .autocomplete(['--time', '--chill', '--repeat'])
   .option('-t, --time <time>', 'Set the time of the Pomodoro. Default is 25:00 minutes.')
   .option('-c, --chill <chill>', 'Set the time of chill. Default is 5:00 minutes.')
-  .option('-r, --repeat <repeat>', 'Run x Pomodoros. Default is 1. To run continuous Pomodoros, set to 0')
+  .option('-r, --repeat <repeat>', 'Repeat Pomodoro x times. Default is 1')
+  .option('-l, --loop', 'Run Pomodoros forever.')
   .action((args = {}, cb) => {
     let times = args.options.time || [defaultTime]
     let chills = args.options.chill || [chillTime]
-    repeatTime = args.options.repeat || defaultRepeat
 
     if (!Array.isArray(times)) {
       times = [times]
@@ -121,8 +118,8 @@ vorpal
       )
       cb()
     } else {
-      // Debug
-      clearLineAndWrite(`🛠 debug passing in repeat time ${repeatTime}`)
+      repeatTime = args.options.repeat || defaultRepeat
+      loop = args.options.loop || false
       performPomodoro(times, chills, 0, cb)
     }
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pomd",
-  "version": "2.3.4",
+  "version": "2.4.4",
   "description": "Just a good old cli based Pomodoro timer with native notifactions",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Added

1. --repeat param to set a fixed number of sessions.
`start -t 25m -c 5m -r 6`
run 25 minute sessions with 5 minute chill, 6 times.

2. show ∞ beside the timer when --loop is enabled